### PR TITLE
feat: private collections (to Figma) & unpack nested tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "rules": {
       "no-restricted-syntax": "off",
       "no-await-in-loop": "off",
+      "no-labels": "off",
+      "no-continue": "off",
       "no-console": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "no-continue": "off",
       "no-console": "off",
       "no-underscore-dangle": "off",
+      "no-use-before-define": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "no-labels": "off",
       "no-continue": "off",
       "no-console": "off",
+      "no-underscore-dangle": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {


### PR DESCRIPTION
- Collections starting with _ are not exported from Figma
- `value` and `type` keys of variables do not use the `$` prefix anymore
- `Foreground` and `Base` variables are expanded